### PR TITLE
Fix bitmap rotated bug after take photo

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -359,9 +359,9 @@ public class Camera1 extends CameraImpl {
                 getCaptureResolution().getWidth(),
                 getCaptureResolution().getHeight()
         );
-        int rotation = (calculateCameraRotation(mDisplayOrientation)
-                + (mFacing == CameraKit.Constants.FACING_FRONT ? 180 : 0) ) % 360;
-        mCameraParameters.setRotation(rotation);
+        // int rotation = (calculateCameraRotation(mDisplayOrientation)
+        //         + (mFacing == CameraKit.Constants.FACING_FRONT ? 180 : 0) ) % 360;
+        // mCameraParameters.setRotation(rotation);
 
         setFocus(mFocus);
         setFlash(mFlash);

--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -42,6 +42,7 @@ public class Camera1 extends CameraImpl {
     private Camera.AutoFocusCallback mAutofocusCallback;
 
     private int mDisplayOrientation;
+    private int mCameraRotation;
 
     @Facing
     private int mFacing;
@@ -295,6 +296,11 @@ public class Camera1 extends CameraImpl {
         return mCamera != null;
     }
 
+    @Override
+    int getCameraRotation() {
+        return mCameraRotation;
+    }
+
     // Internal:
 
     private void openCamera() {
@@ -306,9 +312,7 @@ public class Camera1 extends CameraImpl {
         mCameraParameters = mCamera.getParameters();
 
         adjustCameraParameters();
-        mCamera.setDisplayOrientation(
-                calculateCameraRotation(mDisplayOrientation)
-        );
+        updateRotation();
 
         mCameraListener.onCameraOpened();
     }
@@ -336,12 +340,16 @@ public class Camera1 extends CameraImpl {
         }
     }
 
-    private int calculateCameraRotation(int rotation) {
+    private void updateRotation() {
+        int rotation;
         if (mCameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-            return (360 - (mCameraInfo.orientation + rotation) % 360) % 360;
+            rotation = (360 - (mCameraInfo.orientation + mDisplayOrientation) % 360) % 360;
+            mCameraRotation = rotation + 180;
         } else {
-            return (mCameraInfo.orientation - rotation + 360) % 360;
+            rotation = (mCameraInfo.orientation - mDisplayOrientation + 360) % 360;
+            mCameraRotation = rotation;
         }
+        mCamera.setDisplayOrientation(rotation);
     }
 
     private void adjustCameraParameters() {

--- a/camerakit/src/main/api21/com/flurgle/camerakit/Camera2.java
+++ b/camerakit/src/main/api21/com/flurgle/camerakit/Camera2.java
@@ -191,6 +191,12 @@ class Camera2 extends CameraImpl {
         return mCamera != null;
     }
 
+    @Override
+    int getCameraRotation() {
+        // TODO:
+        return 0;
+    }
+
     // Internal
 
     private List<Size> getAvailableCaptureResolutions() {

--- a/camerakit/src/main/base/com/flurgle/camerakit/CameraImpl.java
+++ b/camerakit/src/main/base/com/flurgle/camerakit/CameraImpl.java
@@ -28,5 +28,6 @@ abstract class CameraImpl {
     abstract Size getCaptureResolution();
     abstract Size getPreviewResolution();
     abstract boolean isCameraOpened();
+    abstract int getCameraRotation();
 
 }

--- a/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
+++ b/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
@@ -266,6 +266,10 @@ public class CameraView extends FrameLayout {
         return mCameraImpl != null ? mCameraImpl.getCaptureResolution() : null;
     }
 
+    public int getCameraRotation() {
+        return mCameraImpl != null ? mCameraImpl.getCameraRotation() : 0;
+    }
+
     private void requestCameraPermission() {
         Activity activity = null;
         Context context = getContext();

--- a/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
+++ b/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
@@ -116,6 +116,7 @@ public class MainActivity extends AppCompatActivity implements View.OnLayoutChan
                 long callbackTime = System.currentTimeMillis();
                 Bitmap bitmap = BitmapFactory.decodeByteArray(jpeg, 0, jpeg.length);
                 ResultHolder.dispose();
+                ResultHolder.setCameraRotation(camera.getCameraRotation());
                 ResultHolder.setImage(bitmap);
                 ResultHolder.setNativeCaptureSize(
                         captureModeRadioGroup.getCheckedRadioButtonId() == R.id.modeCaptureStandard ?

--- a/demo/src/main/java/com/flurgle/camerakit/demo/PreviewActivity.java
+++ b/demo/src/main/java/com/flurgle/camerakit/demo/PreviewActivity.java
@@ -2,6 +2,7 @@ package com.flurgle.camerakit.demo;
 
 import android.app.Activity;
 import android.graphics.Bitmap;
+import android.graphics.Matrix;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.widget.ImageView;
@@ -42,7 +43,7 @@ public class PreviewActivity extends Activity {
             return;
         }
 
-        imageView.setImageBitmap(bitmap);
+        imageView.setImageBitmap(rotateBitmap(bitmap));
 
         Size captureSize = ResultHolder.getNativeCaptureSize();
         if (captureSize != null) {
@@ -60,4 +61,13 @@ public class PreviewActivity extends Activity {
         return (bitmap.getRowBytes() * bitmap.getHeight()) / 1024 / 1024;
     }
 
+    private Bitmap rotateBitmap(Bitmap bitmap) {
+        Matrix matrix = new Matrix();
+        // because this case only support portrait,
+        // so here we can just simply rotate back 90 degree
+        matrix.setRotate(90);
+        return Bitmap.createBitmap(bitmap, 0, 0,
+                bitmap.getWidth(), bitmap.getHeight(),
+                matrix, true);
+    }
 }

--- a/demo/src/main/java/com/flurgle/camerakit/demo/PreviewActivity.java
+++ b/demo/src/main/java/com/flurgle/camerakit/demo/PreviewActivity.java
@@ -63,9 +63,7 @@ public class PreviewActivity extends Activity {
 
     private Bitmap rotateBitmap(Bitmap bitmap) {
         Matrix matrix = new Matrix();
-        // because this case only support portrait,
-        // so here we can just simply rotate back 90 degree
-        matrix.setRotate(90);
+        matrix.setRotate(ResultHolder.getCameraRotation());
         return Bitmap.createBitmap(bitmap, 0, 0,
                 bitmap.getWidth(), bitmap.getHeight(),
                 matrix, true);

--- a/demo/src/main/java/com/flurgle/camerakit/demo/ResultHolder.java
+++ b/demo/src/main/java/com/flurgle/camerakit/demo/ResultHolder.java
@@ -12,7 +12,7 @@ public class ResultHolder {
     private static WeakReference<Bitmap> image;
     private static Size nativeCaptureSize;
     private static long timeToCallback;
-
+    private static int cameraRotation;
 
     public static void setImage(@Nullable Bitmap image) {
         ResultHolder.image = image != null ? new WeakReference<>(image) : null;
@@ -40,10 +40,19 @@ public class ResultHolder {
         return timeToCallback;
     }
 
+    public static void setCameraRotation(int cameraRotation) {
+        ResultHolder.cameraRotation = cameraRotation;
+    }
+
+    public static int getCameraRotation() {
+        return cameraRotation;
+    }
+
     public static void dispose() {
         setImage(null);
         setNativeCaptureSize(null);
         setTimeToCallback(0);
+        setCameraRotation(0);
     }
 
 }


### PR DESCRIPTION
hey @gogopop, many guys ( #36 #14 #10 ) complained the bitmap rotation problem, I also met the same problem, in some phones it is ok, but in others, it is rotated.

after many tries, I think there are two reasons:

1. The first, you don't rotate the bitmap back in PreviewActivity, we should rotate it back 90 degrees in portrait mode.

1. After doing the above change, then the phones rotated become normal while the normals become rotated, so I found you called `mCameraParameters.setRotation(rotation)` in `Camera1.java` line 364, you changed the rotation parameter, I don't think we need this, so I comment it, then all my phones become ok (Meizu MX4 Pro, Samsung Galaxy S5, Xiaomi RedMi Note3), if you need I can supply screenshots.

Just find simply rotate 90 back doesn't work for the front camera, please wait for me to fix that. we should store that rotation in the bottom layer, and then directly use that value in the top layer.