### PR TITLE
fixed wrong rotated front camera videos

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -483,7 +483,7 @@ public class Camera1 extends CameraImpl {
 
         mVideoFile = new File(mPreview.getView().getContext().getExternalFilesDir(null), "video.mp4");
         mMediaRecorder.setOutputFile(mVideoFile.getAbsolutePath());
-        mMediaRecorder.setOrientationHint(calculatePreviewRotation());
+        mMediaRecorder.setOrientationHint(calculateCaptureRotation());
         mMediaRecorder.setVideoSize(mCaptureSize.getWidth(), mCaptureSize.getHeight());
     }
 


### PR DESCRIPTION
Videos taken with front camera are upside down on all my test devices.
Fixed this bug by calling calculateCaptureRotation() instead of calculatePreviewRotation() for MediaRecorder.setOrientationHint()

Working as intended with this change now.

Tested on these devices:
- Samsung Galaxy A5
- Samsung Galaxy Note 3
- Huawei Mate 9
- OnePlus 5