### PR TITLE
Enable Fixed Layout & Chromebook Support

### DIFF
--- a/camerakit/build.gradle
+++ b/camerakit/build.gradle
@@ -33,7 +33,7 @@ android {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:25.2.0'
-
+    compile "com.android.support:exifinterface:25.2.0"
 
     compile 'android.arch.lifecycle:runtime:1.0.0-alpha1'
     compile 'android.arch.lifecycle:extensions:1.0.0-alpha1'

--- a/camerakit/src/main/api21/com/flurgle/camerakit/Camera2.java
+++ b/camerakit/src/main/api21/com/flurgle/camerakit/Camera2.java
@@ -3,7 +3,6 @@ package com.flurgle.camerakit;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.ImageFormat;
-import android.graphics.PointF;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraDevice;
@@ -89,7 +88,7 @@ class Camera2 extends CameraImpl {
     }
 
     @Override
-    void setDisplayOrientation(int displayOrientation) {
+    void setDisplayAndDeviceOrientation(int displayOrientation, int deviceOrientation) {
 
     }
 
@@ -230,6 +229,24 @@ class Camera2 extends CameraImpl {
     @Override
     boolean isCameraOpened() {
         return mCamera != null;
+    }
+
+    @Override
+    boolean frontCameraOnly() {
+        try {
+            for (final String cameraId : mCameraManager.getCameraIdList()) {
+                CameraCharacteristics characteristics = mCameraManager.getCameraCharacteristics(cameraId);
+                @SuppressWarnings("ConstantConditions")
+                int orientation = characteristics.get(CameraCharacteristics.LENS_FACING);
+                if (orientation == CameraCharacteristics.LENS_FACING_BACK) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (CameraAccessException e) {
+            throw new RuntimeException("Failed to get camera view angles", e);
+        }
     }
 
     @Nullable

--- a/camerakit/src/main/base/com/flurgle/camerakit/CameraImpl.java
+++ b/camerakit/src/main/base/com/flurgle/camerakit/CameraImpl.java
@@ -15,7 +15,7 @@ abstract class CameraImpl {
     abstract void start();
     abstract void stop();
 
-    abstract void setDisplayOrientation(int displayOrientation);
+    abstract void setDisplayAndDeviceOrientation(int displayOrientation, int deviceOrientation);
 
     abstract void setFacing(@Facing int facing);
     abstract void setFlash(@Flash int flash);
@@ -31,6 +31,7 @@ abstract class CameraImpl {
     abstract Size getCaptureResolution();
     abstract Size getPreviewResolution();
     abstract boolean isCameraOpened();
+    abstract boolean frontCameraOnly();
 
     @Nullable
     abstract CameraProperties getCameraProperties();

--- a/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
+++ b/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
@@ -499,7 +499,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
             if(ExifUtil.getExifOrientation(jpeg) != ExifInterface.ORIENTATION_NORMAL || mFacing == FACING_FRONT){
                 Bitmap bitmap = ExifUtil.decodeBitmapWithRotation(jpeg, mFacing == FACING_FRONT);
                 ByteArrayOutputStream stream = new ByteArrayOutputStream();
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+                bitmap.compress(Bitmap.CompressFormat.JPEG, mJpegQuality, stream);
                 jpeg = stream.toByteArray();
             }
 

--- a/camerakit/src/main/utils/com/flurgle/camerakit/ExifUtil.java
+++ b/camerakit/src/main/utils/com/flurgle/camerakit/ExifUtil.java
@@ -1,0 +1,88 @@
+package com.flurgle.camerakit;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+import android.support.media.ExifInterface;
+import android.util.Log;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+//import android.media.ExifInterface;
+
+/**
+ * Created by andrew on 2017-08-18.
+ */
+
+public class ExifUtil {
+
+    public static int getExifOrientation(byte[] picture){
+        int orientation = ExifInterface.ORIENTATION_UNDEFINED;
+        try {
+            orientation = getExifOrientation(new ByteArrayInputStream(picture));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return orientation;
+    }
+
+    public static Bitmap decodeBitmapWithRotation(byte[] picture, boolean frontFacing) {
+        Bitmap bitmap = BitmapFactory.decodeByteArray(picture, 0, picture.length);
+        Matrix matrix = getBitmapRotation(picture, frontFacing);
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+    }
+
+    public static Matrix getBitmapRotation(byte[] picture, boolean frontFacing) {
+        int orientation = ExifInterface.ORIENTATION_UNDEFINED;
+        try {
+            orientation = getExifOrientation(new ByteArrayInputStream(picture));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        Matrix matrix = new Matrix();
+
+        switch (orientation) {
+            case ExifInterface.ORIENTATION_FLIP_HORIZONTAL:
+                matrix.setScale(-1, 1);
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_180:
+                matrix.setRotate(180);
+                break;
+            case ExifInterface.ORIENTATION_FLIP_VERTICAL:
+                matrix.setRotate(180);
+                matrix.postScale(-1, 1);
+                break;
+            case ExifInterface.ORIENTATION_TRANSPOSE:
+                matrix.setRotate(90);
+                matrix.postScale(-1, 1);
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                matrix.setRotate(90);
+                break;
+            case ExifInterface.ORIENTATION_TRANSVERSE:
+                matrix.setRotate(-90);
+                matrix.postScale(-1, 1);
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                matrix.setRotate(-90);
+                break;
+            case ExifInterface.ORIENTATION_NORMAL:
+            case ExifInterface.ORIENTATION_UNDEFINED:
+                break;
+        }
+
+        if(frontFacing){
+            matrix.postScale(-1, 1);
+        }
+
+        return matrix;
+    }
+
+    private static int getExifOrientation(InputStream inputStream) throws IOException {
+        ExifInterface exif = new ExifInterface(inputStream);
+        return exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+    }
+}


### PR DESCRIPTION
Thanks again for writing this great library! I ended up forking it & adding some other stuff in that I needed, but wanted to share some tweaks/fixes I made that felt useful to others.

## What this PR Addresses

- Handles the situation where a screenOrientation is fixed, but the device is rotated. Our camera activity is fixed to portrait, but we've found a lot of people still end up holding the device in landscape while taking photos/videos. In these situations, it's good to rotate the captured image/video accordingly.
- Deals with Chromebooks & their odd configurations. With Chromebooks now supporting Android apps, need to handle situations like a) One camera (front-facing), b) No accelerometer & c) Two screen modes (laptop & tablet).
- Check for EXIF orientation metadata for older devices (they sometimes just set this info instead of returning the correctly rotated image).