### PR TITLE
Fix on corrupted preview in landscape device orientation

### DIFF
--- a/camerakit/src/main/api16/com/wonderkiln/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/wonderkiln/camerakit/Camera1.java
@@ -613,11 +613,19 @@ public class Camera1 extends CameraImpl {
         Camera.Parameters resolutionLess = mCamera.getParameters();
 
         if (getPreviewResolution() != null) {
-            mPreview.setPreviewParameters(
-                    getPreviewResolution().getWidth(),
-                    getPreviewResolution().getHeight(),
-                    mCameraParameters.getPreviewFormat()
-            );
+            if (mDeviceOrientation == 0 || mDeviceOrientation == 180) {
+                mPreview.setPreviewParameters(
+                        getPreviewResolution().getWidth(),
+                        getPreviewResolution().getHeight(),
+                        mCameraParameters.getPreviewFormat()
+                );
+            } else {
+                mPreview.setPreviewParameters(
+                        getPreviewResolution().getHeight(),
+                        getPreviewResolution().getWidth(),
+                        mCameraParameters.getPreviewFormat()
+                );
+            }
 
             mCameraParameters.setPreviewSize(
                     invertPreviewSizes ? getPreviewResolution().getHeight() : getPreviewResolution().getWidth(),


### PR DESCRIPTION
I've fixed [issue](https://github.com/wonderkiln/CameraKit-Android/issues/216) created by me several hours ago that accords to corrupted camera preview when trying to start/restart camera in landscape device orientation. 