### PR TITLE
Fixed TYPE_IMAGE_CAPTURED constant to not collide with TYPE_VIDEO_CAPT…

### DIFF
--- a/camerakit/src/main/events/com/wonderkiln/camerakit/CameraKitEvent.java
+++ b/camerakit/src/main/events/com/wonderkiln/camerakit/CameraKitEvent.java
@@ -12,7 +12,7 @@ public class CameraKitEvent {
     public static final String TYPE_FACING_CHANGED = "CKFacingChangedEvent";
     public static final String TYPE_FLASH_CHANGED = "CKFlashChangedEvent";
 
-    public static final String TYPE_IMAGE_CAPTURED = "CKVideoCapturedEvent";
+    public static final String TYPE_IMAGE_CAPTURED = "CKImageCapturedEvent";
     public static final String TYPE_VIDEO_CAPTURED = "CKVideoCapturedEvent";
 
     private String type;


### PR DESCRIPTION
Hello,

`TYPE_IMAGE_CAPTURED` and `TYPE_VIDEO_CAPTURED` string constants were identical which will cause issues if using both video and image captures. 

