### PR TITLE
Load dependencies of native libraries explicitly

### DIFF
--- a/camerakit-core/src/main/utils/com/wonderkiln/camerakit/BitmapOperator.java
+++ b/camerakit-core/src/main/utils/com/wonderkiln/camerakit/BitmapOperator.java
@@ -78,6 +78,9 @@ public class BitmapOperator {
     }
 
     static {
+        System.loadLibrary("jpge");
+        System.loadLibrary("jpgd");
+        System.loadLibrary("JniYuvOperator");
         System.loadLibrary("JniBitmapOperator");
     }
 


### PR DESCRIPTION
This fixes https://github.com/wonderkiln/CameraKit-Android/issues/256

In Android API 17 and bellow, we need to load the native libraries and their dependencies explicitly.

Here is some more information.

https://stackoverflow.com/questions/36523358/android-ndk-cannot-load-library-load-library-on-android-17-and-below
https://developer.android.com/ndk/guides/cpp-support.html#sr

Please let me know if there is any changes required to merge this.
Thanks